### PR TITLE
Bugfix mutex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 CC=gcc
-CFLAGS=-I. -I/opt/ss/include -fPIC -g
+CFLAGS=-I. -I/opt/ss/include -fPIC -g -D _GNU_SOURCE
 # The -lrt flag is needed to avoid a link error related to clock_* methods if glibc < 2.17
 LDFLAGS += -ljson-c -lpthread -L/opt/ss/lib64 -lrt -lm
-DEPS = proxyfs.h
+
+DEPS = base64.h debug.h fault_inj.h ioworker.h json_utils.h json_utils_internal.h pool.h proxyfs.h proxyfs_jsonrpc.h proxyfs_req_resp.h proxyfs_testing.h socket.h time_utils.h
+
 LIBINSTALL?=/usr/lib
 LIBINSTALL_CENTOS?=/usr/lib64
+
 INCLUDEDIR?=/usr/include
 
 %.o: %.c $(DEPS)
@@ -13,26 +16,45 @@ INCLUDEDIR?=/usr/include
 all: libproxyfs.so.1.0.0 test
 
 libproxyfs.so.1.0.0: proxyfs_api.o proxyfs_jsonrpc.o proxyfs_req_resp.o json_utils.o base64.o socket.o pool.o ioworker.o time_utils.o fault_inj.o
-	$(CC) -shared -fPIC -Wl,-soname,libproxyfs.so.1 -o libproxyfs.so.1.0.0 proxyfs_api.o proxyfs_jsonrpc.o proxyfs_req_resp.o json_utils.o base64.o socket.o pool.o ioworker.o time_utils.o fault_inj.o $(LDFLAGS) -lc
+	$(CC) -shared -fPIC -Wl,-soname,libproxyfs.so.1 -o $@ $+ $(LDFLAGS) -lc
 	ln -f -s ./libproxyfs.so.1.0.0 ./libproxyfs.so.1
 	ln -f -s ./libproxyfs.so.1.0.0 ./libproxyfs.so
 
 
 test: proxyfs_api.o proxyfs_jsonrpc.o proxyfs_req_resp.o json_utils.o base64.o socket.o pool.o ioworker.o time_utils.o fault_inj.o test.o
-	$(CC) -o test proxyfs_api.o proxyfs_jsonrpc.o proxyfs_req_resp.o json_utils.o base64.o socket.o pool.o ioworker.o time_utils.o fault_inj.o test.o $(CFLAGS) $(LDFLAGS)
+	$(CC) -o $@ $(CFLAGS) $+ $(LDFLAGS)
 
 install:
-	cp -f libproxyfs.so.1.0.0 $(LIBINSTALL)/libproxyfs.so.1.0.0
-	ln -f -s $(LIBINSTALL)/libproxyfs.so.1.0.0 $(LIBINSTALL)/libproxyfs.so.1
-	ln -f -s $(LIBINSTALL)/libproxyfs.so.1.0.0 $(LIBINSTALL)/libproxyfs.so
-	cp -f ./proxyfs.h $(INCLUDEDIR)/
+	cp -f ./proxyfs.h $(INCLUDEDIR)/.
+	@if [ ! -f /etc/os-release ]; then \
+		echo "ERROR: Could not determine OS environment; /etc/os-release does not exist" 1>&2; \
+		exit 2; \
+	fi
+	@. /etc/os-release; \
+	case "X$$ID" in \
+	Xcentos) LIBDIR=$(LIBINSTALL_CENTOS); \
+		;; \
+	Xubuntu) LIBDIR=$(LIBINSTALL); \
+		;; \
+	X) \
+		echo "ERROR: /etc/os-release does not specify a value for 'ID'" 1>&2; \
+		exit 2; \
+		;; \
+	*) \
+		echo "ERROR: /etc/os-release specified an unknown 'ID' '$ID'" 1>&2; \
+		exit 2; \
+		;; \
+	esac; \
+	echo cp -f libproxyfs.so.1.0.0 $$LIBDIR/libproxyfs.so.1.0.0; \
+	cp -f libproxyfs.so.1.0.0 $$LIBDIR/libproxyfs.so.1.0.0; \
+	echo ln -f -s libproxyfs.so.1.0.0 $$LIBDIR/libproxyfs.so.1; \
+	ln -f -s libproxyfs.so.1.0.0 $$LIBDIR/libproxyfs.so.1; \
+	echo ln -f -s libproxyfs.so.1.0.0 $$LIBDIR/libproxyfs.so; \
+	ln -f -s libproxyfs.so.1.0.0 $$LIBDIR/libproxyfs.so
 
-installcentos:
-	cp -f libproxyfs.so.1.0.0 $(LIBINSTALL_CENTOS)/libproxyfs.so.1.0.0
-	ln -f -s $(LIBINSTALL_CENTOS)/libproxyfs.so.1.0.0 $(LIBINSTALL_CENTOS)/libproxyfs.so.1
-	ln -f -s $(LIBINSTALL_CENTOS)/libproxyfs.so.1.0.0 $(LIBINSTALL_CENTOS)/libproxyfs.so
-	cp -f ./proxyfs.h $(INCLUDEDIR)/
+# the installcentos target is deprecated
+#
+installcentos:install
 
 clean:
-	rm -f *.o libproxyfs.so.1.0.0 ./libproxyfs.so.1 ./libproxyfs.so test pfs_log pfs_ping pfs_rw
-
+	rm -f *.o libproxyfs.so.1.0.0 libproxyfs.so.1 libproxyfs.so test pfs_log pfs_ping pfs_rw

--- a/debug.h
+++ b/debug.h
@@ -2,6 +2,7 @@
 #define __PFS_DEBUG_H__
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <inttypes.h>
 
 // Defined in proxyfs_api.c. Go there to change the default for debug printfs.
@@ -14,7 +15,7 @@ extern int list_debug_flag;
 
 // This is a roll-your-own panic. Sigh.
 #define PANIC(fmt, ...) \
-    do { printf("PANIC [%p]: " fmt, ((void*)((uint64_t)pthread_self())), ##__VA_ARGS__); fflush(stdout); abort(); } while (0)
+    do { printf("PANIC [%p]: " fmt "\n", ((void*)((uint64_t)pthread_self())), ##__VA_ARGS__); fflush(stdout); abort(); } while (0)
 
 #define DPANIC(fmt, ...) \
     do { if (debug_flag>0) PANIC(fmt, ##__VA_ARGS__); PRINTF(fmt, ##__VA_ARGS__); } while (0)

--- a/pool.c
+++ b/pool.c
@@ -5,6 +5,7 @@
  * sock_pool_t *sock_pool_create(char *server, int port, int count);
  * int sock_pool_get(sock_pool_t *pool);
  * void sock_pool_put(sock_pool_t *pool, int sock_fd);
+ * void sock_pool_put_badfd(sock_pool_t *pool, int sock_fd);
  * int sock_pool_select(sock_pool_t *pool);
  * int sock_pool_destroy(sock_pool_t *pool);
  */
@@ -39,21 +40,15 @@ sock_pool_t *sock_pool_create(char *server, int port, int count)
 
     sock_pool_t *pool = (sock_pool_t *)malloc(sizeof(sock_pool_t));
     if (pool == NULL) {
-        errno = ENOMEM;
-        return NULL;
+        PANIC("sock_pool_create(): could not malloc memory for sock_pool_t");
     }
     bzero(pool, sizeof(sock_pool_t));
 
-    pool->server = (char *)malloc(strlen(server) + 1);
-    if (pool->server == NULL) {
-        free(pool);
-        errno = ENOMEM;
-        return NULL;
-    }
-
+    pool->server = strdup(server);
     pool->network = strdup("tcp");
-
-    strcpy(pool->server, server);
+    if (pool->server == NULL || pool->network == NULL) {
+        PANIC("sock_pool_create(): could not malloc memory for 'tcp' or for server name: '%s'", server);
+    }
     pool->port = port;
     pool->pool_count = count;
     pthread_mutex_init(&pool->pool_lock, NULL);
@@ -63,10 +58,7 @@ sock_pool_t *sock_pool_create(char *server, int port, int count)
     pool->free_pool = NULL;
     pool->fd_list = (int *)malloc(sizeof(int) * count);
     if (pool->fd_list == NULL) {
-        free(pool->server);
-        free(pool);
-        errno = ENOMEM;
-        return NULL;
+        PANIC("sock_pool_create(): could not malloc memory for %d file descriptors", count);
     }
     bzero(pool->fd_list, sizeof(int) * count);
 
@@ -74,17 +66,12 @@ sock_pool_t *sock_pool_create(char *server, int port, int count)
     for (i = 0; i < pool->pool_count; i++) {
         sock_info_t *sock_info = (sock_info_t *)malloc(sizeof(sock_info_t));
         if (sock_info == NULL) {
-            errno = ENOMEM;
-            goto cleanup;
+            PANIC("sock_pool_create(): could not malloc memory for sock_info_t number %d", i);
         }
         bzero(sock_info, sizeof(sock_info_t));
 
-        sock_info->sock_fd = sock_open(server, port);
-        if (sock_info->sock_fd < 0)  {
-            free(sock_info);
-            goto cleanup;
-        }
-        pool->fd_list[i] = sock_info->sock_fd;
+        sock_info->sock_idx = i;
+        pool->fd_list[i] = -1;
 
         if (i == 0) {
             pool->free_pool = sock_info;
@@ -95,32 +82,88 @@ sock_pool_t *sock_pool_create(char *server, int port, int count)
         }
     }
 
-cleanup:
-    if (i != pool->pool_count) { // Failed to allocate required number of sockets.
-        sock_list_free(pool->free_pool);
-
-        free(pool->fd_list);
-        free(pool->server);
-        free(pool->network);
-        free(pool);
-
-        return NULL;
+    // verify we can open a connection
+    int         fd = sock_pool_get(pool);
+    if (fd < 0) {
+        goto errout;
     }
+    sock_pool_put(pool, fd);
 
     return pool;
+
+errout:
+    // close any open sockets (this can't really happen)
+    if (pool->fd_list != NULL) {
+        int     i;
+        for (i = 0; i < pool->pool_count; i++) {
+            if (pool->fd_list[i] >= 0) {
+                close(pool->fd_list[i]);
+                pool->fd_list[i] = -1;
+            }
+        }
+    }
+
+    // its OK to call free() or sock_list_free() with a NULL pointer
+    sock_list_free(pool->free_pool);
+    free(pool->fd_list);
+    free(pool->server);
+    free(pool->network);
+    free(pool);
+
+    if (errno == 0) {
+        errno = EBADF;
+    }
+    return NULL;
 }
 
 // sock_pool_get: Will return a socket fd from the free pool. If there is no socket in the free pool, this
 //                routine will block until a socket becomes available.
+//
+// If a socket cannot be opened, -1 is returned.
 int sock_pool_get(sock_pool_t *pool)
 {
     if (pool == NULL) {
+        errno = EBADF;
         return -1;
     }
 
     pthread_mutex_lock(&pool->pool_lock);
-    while (pool->available_count <= 0) {
+    while (pool->available_count <= 0 || pool->pool_blocked) {
         pthread_cond_wait(&pool->pool_cv, &pool->pool_lock);
+    }
+
+    // If the first socket is not open then all of them must be closed -- open
+    // all of them.  This is necessary because sock_pool_select() is not
+    // informed when we open a new socket, so it will not be in the list of fd
+    // passed to select(2) and sock_pool_select() will not find out a packet
+    // arrived on the new socket until the next time out or a packet arrives on
+    // a different socket.
+    if (pool->fd_list[0] < 0) {
+
+        DPRINTF("sock_pool_get(): opening sockets");
+        int     i;
+        for (i = 0; i < pool->pool_count; i++) {
+            if (pool->fd_list[i] >= 0) {
+                PANIC("sock_pool_get(): found an unexpected open socket at index %d", i);
+            }
+
+            pool->fd_list[i] = sock_open(pool->server, pool->port);
+
+            // if an open failed, close them all and leave
+            if (pool->fd_list[i] < 0) {
+                int     errno_save = errno;
+                DPRINTF("sock_pool_get(): open of socket %d failed: %s", i, strerror(errno_save));
+
+                int     j;
+                for (j = 0; j < i; j++) {
+                    sock_close(pool->fd_list[j]);
+                    pool->fd_list[j] = -1;
+                }
+
+                errno = errno_save;
+                return -1;
+            }
+        }
     }
 
     pool->available_count--;
@@ -131,7 +174,7 @@ int sock_pool_get(sock_pool_t *pool)
 
     pthread_mutex_unlock(&pool->pool_lock);
 
-    return sock_info->sock_fd;
+    return pool->fd_list[sock_info->sock_idx];
 }
 
 // sock_pool_put: Put back the socket into free pool. Will wakeup if anyone is waiting for a socket.
@@ -147,7 +190,7 @@ void sock_pool_put(sock_pool_t *pool, int sock_fd)
     sock_info_t *head = pool->busy_pool;
 
     while (head != NULL) {
-        if (head->sock_fd != sock_fd) {
+        if (pool->fd_list[head->sock_idx] != sock_fd) {
             prev = head;
             head = head->next;
             continue;
@@ -172,13 +215,64 @@ void sock_pool_put(sock_pool_t *pool, int sock_fd)
     pthread_mutex_unlock(&pool->pool_lock);
 }
 
+// sock_pool_put_badfd: Put a socket back to the pool after a read() or write()
+// on the socket failed.
+//
+// This code assumes that all the connections in the pool are bad so it blocks
+// new get requests, returns the socket to the pool and waits until all other
+// outstanding sockets are returned.  Then it closes all the sockets, unblocks
+// the pool and lets callers to sock_pool_get() try to re-open them.
+void sock_pool_put_badfd(sock_pool_t *pool, int sock_fd)
+{
+    pthread_mutex_lock(&pool->pool_lock);
+
+    // the first thread to notice will clean things up
+    if (pool->pool_blocked) {
+        pthread_mutex_unlock(&pool->pool_lock);
+        sock_pool_put(pool, sock_fd);
+        return;
+    }
+
+    // block any new get requests
+    pool->pool_blocked = true;
+    pthread_mutex_unlock(&pool->pool_lock);
+
+    sock_pool_put(pool, sock_fd);
+
+    // wait until all fd are released
+    pthread_mutex_lock(&pool->pool_lock);
+    while (pool->available_count < pool->pool_count) {
+        pthread_cond_wait(&pool->pool_cv, &pool->pool_lock);
+    }
+
+    // close all the file descriptors
+    //
+    // TODO: what if one of the fd was good and there's an outstanding request
+    // on it?
+    int         i;
+    for (i = 0; i < pool->pool_count; i++) {
+        if (pool->fd_list[i] >= 0) {
+            close(pool->fd_list[i]);
+            pool->fd_list[i] = -1;
+        }
+    }
+
+    // unblock the pool and wake any waiters
+    pthread_mutex_lock(&pool->pool_lock);
+    pool->pool_blocked = false;
+    pthread_cond_broadcast(&pool->pool_cv);
+    pthread_mutex_unlock(&pool->pool_lock);
+}
+
 // sock_pool_select: Will return a fd that has data to read. If a non-zero timeout value is specified,
 //                   select will wait for the timeout period and if no data to read will return 0.
 //
-// NOTE: if something is blocked on this select call and other code calls sock_pool_destroy/create, the
-//       sock fds will have changed out from under the select. In that case, the select will time out and
-//       the next select will succeed. This manifests as unexpected 5-second (or whatever the timeout)
-//       delays in getting responses from ProxyFS.
+// NOTE: if something is blocked on this select call and other code calls
+//       sock_pool_destroy()/_create() sock_pool_put_badfd(), the sock fds will
+//       have changed out from under the select. In that case, the select may
+//       time out or return an error. The next select will succeed. This
+//       manifests as unexpected 5-second (or whatever the timeout) delays in
+//       getting responses from ProxyFS.
 int sock_pool_select(sock_pool_t *pool, int timeout_in_secs)
 {
     if (pool == NULL) {
@@ -200,7 +294,9 @@ int sock_pool_select(sock_pool_t *pool, int timeout_in_secs)
     int i = 0;
     int high_fd = 0;
     for (i = 0; i < pool->pool_count; i++) {
-        FD_SET(pool->fd_list[i], &set);
+        if (pool->fd_list[i] > 0) {
+            FD_SET(pool->fd_list[i], &set);
+        }
         if (pool->fd_list[i] > high_fd) {
             high_fd = pool->fd_list[i];
         }
@@ -214,6 +310,9 @@ int sock_pool_select(sock_pool_t *pool, int timeout_in_secs)
     }
 
     for (i = 0; i < pool->pool_count; i++) {
+        if (pool->fd_list[i] < 0) {
+            continue;
+        }
         if (FD_ISSET(pool->fd_list[i], &set)) {
             return pool->fd_list[i];
         }
@@ -248,6 +347,14 @@ int sock_pool_destroy(sock_pool_t *pool, bool force)
     pthread_mutex_destroy(&pool->pool_lock);
 
     if (pool->fd_list != NULL) {
+        int     i;
+        for (i = 0; i < pool->pool_count; i++) {
+            if (pool->fd_list[i] >= 0) {
+                close(pool->fd_list[i]);
+                pool->fd_list[i] = -1;
+            }
+        }
+
         free(pool->fd_list);
     }
 
@@ -268,7 +375,6 @@ void sock_list_free(sock_info_t *list)
 {
     while (list) {
         sock_info_t *head = list;
-        sock_close(head->sock_fd);
         list = head->next;
         free(head);
     }

--- a/pool.h
+++ b/pool.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 typedef struct sock_info_s {
-    int sock_fd;
+    int sock_idx;
     struct sock_info_s *next;
 } sock_info_t;
 
@@ -17,6 +17,7 @@ typedef struct sock_pool_s {
     pthread_cond_t  pool_cv;
 
     int             available_count;
+    bool            pool_blocked;
     int             *fd_list;
     sock_info_t     *free_pool;
     sock_info_t     *busy_pool;
@@ -25,6 +26,7 @@ typedef struct sock_pool_s {
 sock_pool_t *sock_pool_create(char *server, int port, int count);
 int sock_pool_get(sock_pool_t *pool);
 void sock_pool_put(sock_pool_t *pool, int sock_fd);
+void sock_pool_put_badfd(sock_pool_t *pool, int sock_fd);
 int sock_pool_select(sock_pool_t *pool, int timeout_in_secs);
 int sock_pool_destroy(sock_pool_t *pool, bool force);
 

--- a/proxyfs_api.c
+++ b/proxyfs_api.c
@@ -2943,4 +2943,3 @@ void proxyfs_unset_verbose()
 {
     debug_flag = 0;
 }
-

--- a/proxyfs_jsonrpc.c
+++ b/proxyfs_jsonrpc.c
@@ -99,7 +99,7 @@ jsonrpc_handle_t* pfs_rpc_open()
     }
 
     // Open the IO socket, if it's not already open
-    if (io_sock_fd == -1) {
+    if (io_sock_fd < 0) {
         io_sock_fd = sock_open(rpc_server, rpc_fast_port);
         if (io_sock_fd < 0) {
             free(handle);
@@ -133,7 +133,10 @@ void pfs_rpc_close(jsonrpc_handle_t* handle)
         return;
     }
 
-    io_workers_stop();
+    // Samba can open multiple handles at one time.  Do not stop i/o workers
+    // until the last handle is closed.
+    //
+    // io_workers_stop();
 
     // TODO: Socket pool once created remains active.. do not remove it.
     // sock_pool_t *local_pool = global_sock_pool;
@@ -684,4 +687,3 @@ int jsonrpc_exec_request_nonblocking(jsonrpc_context_t* ctx, jsonrpc_internal_ca
     }
     return rc;
 }
-

--- a/proxyfs_req_resp.c
+++ b/proxyfs_req_resp.c
@@ -318,11 +318,6 @@ void destruct_ctx(jsonrpc_context_t* ctx)
 {
     if (ctx == NULL) return;
 
-    //DPRINTF("Locking so that we have exclusive access to ctx=%p (pre-lock).\n",ctx);
-
-    // protect have_response flag
-    pthread_mutex_lock(&ctx->cv_info.mutex);
-
     // Free json objects
     json_object_put(ctx->req.request);
     json_object_put(ctx->resp.response);
@@ -510,4 +505,3 @@ jsonrpc_context_t* jsonrpc_get_request_by_cookie(void* cookie)
 {
     return jsonrpc_find_in_list_by_cookie(cookie, &requests_in_progress, &requests_in_progress_lock, request_list_name);
 }
-


### PR DESCRIPTION
Fix the problem afflicting Veeam where backup jobs die because Veeam opens the same file system multiple times in one Samba connection and closes some instances.

Samba passes the close requests down to jrpc client as unmount requests and jrpc client then stops all of the i/o workers.  Bad things  happen when the next i/o request comes along (NULL pointer dereference).

Also try to fix the code that handles socket failure due to disconnection.  This is only a partial fix but should improve things.  Among other outstanding issues is a PANIC() if a ` proxyfs_read_req()` call fails.