### PR TITLE
Upgraded mount mechanism to use cryptocraphically secure MountIDs

### DIFF
--- a/json_utils.c
+++ b/json_utils.c
@@ -262,20 +262,6 @@ json_object* get_jrpc_result(json_object* jobj)
     return find_something(jobj, RESULT_KEY);
 }
 
-uint64_t get_jrpc_mount_id(json_object* jobj)
-{
-    json_object* obj = NULL;
-    // MountID is inside the result object
-    json_object* robj = get_jrpc_result(jobj);
-    if (!json_object_object_get_ex(robj, "MountID", &obj)) {
-        // key was not found
-        DPRINTF("MountID field not found in response!\n");
-        return 0;
-    }
-
-    return json_object_get_int64(obj);
-}
-
 json_object* get_jrpc_resp_array_elem(jsonrpc_context_t* ctx, char* array_key, int index)
 {
     // Get the dirent array from the result

--- a/proxyfs.h
+++ b/proxyfs.h
@@ -22,12 +22,15 @@ void rpc_config_parse(const char *rpc_config_string);
 struct rpc_handle_t;
 typedef struct rpc_handle_t jsonrpc_handle_t;
 
-#define MAX_VOL_NAME_LENGTH   128
-#define MAX_USER_NAME_LENGTH  128
+#define MAX_VOL_NAME_LENGTH  128
+#define MAX_USER_NAME_LENGTH 128
+
+#define MOUNT_ID_SIZE 16
 
 typedef struct {
     jsonrpc_handle_t* rpc_handle;
-    uint64_t          mount_id;
+    char*             mount_id_as_str;
+    uint8_t           mount_id_as_bytes[MOUNT_ID_SIZE];
     uint64_t          root_dir_inode_num;
     char              volume_name[MAX_VOL_NAME_LENGTH];
     uint64_t          mount_options;


### PR DESCRIPTION
This update includes:
  Conversion to use new RpcMountByVolumeName RPC
  Utilizes new Base64-encoded MountIDs for non-Read/Write RPCs
  Utilizes Base64-decoded MountIDs for Read/Write (Fast) RPCs